### PR TITLE
permit macOS/FreeBSD `stat` syntax

### DIFF
--- a/bin/samefile
+++ b/bin/samefile
@@ -19,9 +19,16 @@ main() {
 
   # stat
   #   `-L` to dereference symbolic links # https://superuser.com/a/196655
-  #   `-c` to display %d for device and
-  #                   %i for inode
-  [ "$(stat -L -c %d:%i "${1}")" = "$(stat -L -c %d:%i "${2}")" ] && return 0 || return 1
+  #   `-c`       for GNU to display %d for device and
+  #                                 %i for inode
+  #   `-f` for BSD/macOS to display %d for device and
+  #                                 %i for inode
+  if command stat -L -c '%d:%i' -- . >/dev/null 2>&1; then
+    argument='-c'
+  else
+    argument='-f'
+  fi
+  [ "$(stat -L "${argument-}" %d:%i "${1}" 2>/dev/null)" = "$(stat -L "${argument-}" %d:%i "${2}")" ] && return 0 || return 1
   { set +x; } 2>/dev/null
 
 }

--- a/bin/samefile
+++ b/bin/samefile
@@ -23,7 +23,7 @@ main() {
   #                                 %i for inode
   #   `-f` for BSD/macOS to display %d for device and
   #                                 %i for inode
-  if command stat -L -c '%d:%i' -- . >/dev/null 2>&1; then
+  if stat -L -c '%d:%i' -- . >/dev/null 2>&1; then
     argument='-c'
   else
     argument='-f'


### PR DESCRIPTION
this pull request allows either macOS/FreeBSD using `stat -f`, or GNU/uutils using `stat -c`, to format the device and inode numbers, which fixes #22; see [mathiasbynens/dotfiles #1042](https://github.com/mathiasbynens/dotfiles/pull/1042) and [#1044](https://github.com/mathiasbynens/dotfiles/pull/1044)